### PR TITLE
Secure the '/token/revocation' endpoint

### DIFF
--- a/src/main/java/org/osiam/security/authorization/MeScopeAccessDecisionVoter.java
+++ b/src/main/java/org/osiam/security/authorization/MeScopeAccessDecisionVoter.java
@@ -1,0 +1,118 @@
+package org.osiam.security.authorization;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.osiam.resources.scim.User;
+import org.springframework.security.access.AccessDecisionVoter;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.SecurityConfig;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.vote.ScopeVoter;
+import org.springframework.security.web.FilterInvocation;
+
+import com.google.common.base.Splitter;
+
+public class MeScopeAccessDecisionVoter implements AccessDecisionVoter<FilterInvocation> {
+
+    public static final SecurityConfig SCOPE_DYNAMIC = new SecurityConfig("SCOPE_DYNAMIC");
+    public static final SecurityConfig SCOPE_ME = new SecurityConfig("SCOPE_ME");
+
+    private final ScopeVoter scopeVoter;
+
+    public MeScopeAccessDecisionVoter(ScopeVoter scopeVoter) {
+        this.scopeVoter = scopeVoter;
+    }
+
+    @Override
+    public boolean supports(ConfigAttribute attribute) {
+        return attribute.equals(SCOPE_DYNAMIC);
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return FilterInvocation.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public int vote(Authentication authentication, FilterInvocation filterInvocation,
+            Collection<ConfigAttribute> attributes) {
+
+        String requestUrl = filterInvocation.getRequestUrl();
+        String requestMethod = filterInvocation.getHttpRequest().getMethod();
+
+        if (!canVoteOn(authentication, requestUrl, requestMethod)) {
+            return ACCESS_ABSTAIN;
+        }
+
+        String userId = null;
+        if (authentication.getPrincipal() instanceof User) {
+            userId = ((User) authentication.getPrincipal()).getId();
+        }
+
+        if (!isOwnerOfResource(userId, requestUrl)) {
+            return ACCESS_ABSTAIN;
+        }
+
+        return scopeVoter.vote(authentication, filterInvocation, enhanceConfigAttributes(attributes));
+    }
+
+    private Set<ConfigAttribute> enhanceConfigAttributes(Collection<ConfigAttribute> attributes) {
+        Set<ConfigAttribute> enhancedAttributes = new HashSet<>(attributes);
+        if (enhancedAttributes.contains(SCOPE_DYNAMIC)) {
+            enhancedAttributes.remove(SCOPE_DYNAMIC);
+            enhancedAttributes.add(SCOPE_ME);
+        }
+        return enhancedAttributes;
+    }
+
+    private boolean canVoteOn(Authentication authentication, String url, String method) {
+        if (!(authentication instanceof OAuth2Authentication)) {
+            return false;
+        }
+
+        if (!url.startsWith("/token/revocation")) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean isOwnerOfResource(String userId, String url) {
+        try {
+            String path = new URI(url).getPath();
+
+            if ("/token/revocation".equals(path) || "/token/revocation/".equals(path)) {
+                return true;
+            }
+
+            // userId is null, if access token is bound to a client, not a user
+            if (userId == null) {
+                return false;
+            }
+
+            List<String> pathSegments = Splitter.on('/')
+                    .omitEmptyStrings()
+                    .trimResults()
+                    .splitToList(path);
+
+            if (pathSegments.size() < 3) {
+                return false;
+            }
+
+            String resourceId = pathSegments.get(2);
+            if (userId.equals(resourceId)) {
+                return true;
+            }
+        } catch (URISyntaxException e) {
+            return false;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/org/osiam/security/controller/TokenController.java
+++ b/src/main/java/org/osiam/security/controller/TokenController.java
@@ -41,13 +41,7 @@ import org.springframework.security.oauth2.provider.AuthorizationRequest;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.token.DefaultTokenServices;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * This Controller is used to handle OAuth2 access tokens with Spring Security.
@@ -58,7 +52,7 @@ public class TokenController {
 
     @Inject
     private DefaultTokenServices tokenServices;
-    
+
     @Inject
     private ResourceServerConnector resourceServerConnector;
 
@@ -68,25 +62,25 @@ public class TokenController {
         String token = getToken(authorization);
         OAuth2Authentication auth = tokenServices.loadAuthentication(token);
         OAuth2AccessToken accessToken = tokenServices.getAccessToken(auth);
-        
+
         AuthorizationRequest authReq = auth.getAuthorizationRequest();
         AccessToken.Builder tokenBuilder = new AccessToken.Builder(token).setClientId(authReq.getClientId());
-        
-        if(auth.getUserAuthentication() != null && auth.getPrincipal() instanceof User) {
+
+        if (auth.getUserAuthentication() != null && auth.getPrincipal() instanceof User) {
             User user = (User) auth.getPrincipal();
             tokenBuilder.setUserName(user.getUserName());
             tokenBuilder.setUserId(user.getId());
         }
-        
+
         tokenBuilder.setExpiresAt(accessToken.getExpiration());
-        
+
         for (String scopeString : authReq.getScope()) {
             tokenBuilder.addScope(new Scope(scopeString));
         }
-        
+
         return tokenBuilder.build();
     }
-    
+
     @RequestMapping(value = "/revocation", method = RequestMethod.POST)
     @ResponseBody
     public void tokenRevocation(@RequestHeader("Authorization") final String authorization) {
@@ -104,7 +98,7 @@ public class TokenController {
         String searchKey = new User.Builder(user.getUserName()).setId(id).build().toString();
         Collection<OAuth2AccessToken> tokens = tokenServices.findTokensByUserName(searchKey);
 
-        for (OAuth2AccessToken token : new ArrayList<OAuth2AccessToken>(tokens)) {
+        for (OAuth2AccessToken token : new ArrayList<>(tokens)) {
             tokenServices.revokeToken(token.getValue());
         }
     }
@@ -115,9 +109,9 @@ public class TokenController {
     public AuthenticationError handleClientAuthenticationException(InvalidTokenException ex, HttpServletRequest request) {
         return new AuthenticationError("invalid_token", ex.getMessage());
     }
-    
+
     private String getToken(String authorization) {
-    	int lastIndexOf = authorization.lastIndexOf(' ');
-    	return authorization.substring(lastIndexOf + 1);
+        int lastIndexOf = authorization.lastIndexOf(' ');
+        return authorization.substring(lastIndexOf + 1);
     }
 }

--- a/src/main/java/org/osiam/security/controller/TokenController.java
+++ b/src/main/java/org/osiam/security/controller/TokenController.java
@@ -58,7 +58,7 @@ public class TokenController {
 
     @RequestMapping(value = "/validation", method = RequestMethod.POST)
     @ResponseBody
-    public AccessToken tokenValidation(@RequestHeader("Authorization") final String authorization) {
+    public AccessToken validateToken(@RequestHeader("Authorization") final String authorization) {
         String token = getToken(authorization);
         OAuth2Authentication auth = tokenServices.loadAuthentication(token);
         OAuth2AccessToken accessToken = tokenServices.getAccessToken(auth);
@@ -83,19 +83,19 @@ public class TokenController {
 
     @RequestMapping(value = "/revocation", method = RequestMethod.POST)
     @ResponseBody
-    public void tokenRevocation(@RequestHeader("Authorization") final String authorization) {
+    public void revokeToken(@RequestHeader("Authorization") final String authorization) {
         String token = getToken(authorization);
         tokenServices.revokeToken(token);
     }
 
-    @RequestMapping(value = "/revocation/{id}", method = RequestMethod.POST)
+    @RequestMapping(value = "/revocation/{userId}", method = RequestMethod.POST)
     @ResponseBody
-    public void tokenRevocation(@PathVariable("id") final String id,
-            @RequestHeader("Authorization") final String authorization) {
-        User user = resourceServerConnector.getUserById(id);
+    public void revokeAllTokensOfUser(@PathVariable("userId") final String userId) {
+
+        User user = resourceServerConnector.getUserById(userId);
 
         // the token store maps the tokens of a user to the string representation of the principal
-        String searchKey = new User.Builder(user.getUserName()).setId(id).build().toString();
+        String searchKey = new User.Builder(user.getUserName()).setId(userId).build().toString();
         Collection<OAuth2AccessToken> tokens = tokenServices.findTokensByUserName(searchKey);
 
         for (OAuth2AccessToken token : new ArrayList<>(tokens)) {

--- a/src/main/webapp/WEB-INF/rest-security.xml
+++ b/src/main/webapp/WEB-INF/rest-security.xml
@@ -45,9 +45,16 @@
         <security:access-denied-handler ref="oauthAccessDeniedHandler"/>
     </security:http>
 
-    <security:http pattern="/token/**" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint">
+    <security:http pattern="/token/validation" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint">
+        <security:intercept-url pattern="/token/validation" access="IS_AUTHENTICATED_FULLY"/>
+        <security:custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER"/>
+        <security:access-denied-handler ref="oauthAccessDeniedHandler"/>
+    </security:http>
 
-        <security:intercept-url pattern="/token/**" access="IS_AUTHENTICATED_FULLY"/>
+    <security:http pattern="/token/revocation/**" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint"
+                   access-decision-manager-ref="accessDecisionManager">
+
+        <security:intercept-url pattern="/token/revocation/**" access="SCOPE_DYNAMIC"/>
         <security:custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER"/>
         <security:access-denied-handler ref="oauthAccessDeniedHandler"/>
     </security:http>
@@ -58,15 +65,20 @@
         <property name="realmName" value="oauth2-authorization-server"/>
     </bean>
 
-    <bean id="accessDecisionManager" class="org.springframework.security.access.vote.UnanimousBased"
-          xmlns="http://www.springframework.org/schema/beans">
+    <bean id="scopeVoter" class="org.springframework.security.oauth2.provider.vote.ScopeVoter">
+        <property name="throwException" value="false"/>
+    </bean>
+
+    <bean id="accessDecisionManager" class="org.springframework.security.access.vote.AffirmativeBased">
+        <property name="allowIfAllAbstainDecisions" value="false"/>
 
         <constructor-arg>
             <list>
+                <bean class="org.osiam.security.authorization.MeScopeAccessDecisionVoter">
+                    <constructor-arg ref="scopeVoter"/>
+                </bean>
                 <bean class="org.osiam.security.authorization.DynamicHTTPMethodScopeEnhancer">
-                    <constructor-arg>
-                        <bean class="org.springframework.security.oauth2.provider.vote.ScopeVoter"/>
-                    </constructor-arg>
+                    <constructor-arg ref="scopeVoter"/>
                 </bean>
             </list>
         </constructor-arg>

--- a/src/main/webapp/WEB-INF/rest-security.xml
+++ b/src/main/webapp/WEB-INF/rest-security.xml
@@ -23,66 +23,44 @@
   -->
 
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:oauth="http://www.springframework.org/schema/security/oauth2"
-    xmlns:security="http://www.springframework.org/schema/security"
-    xsi:schemaLocation="http://www.springframework.org/schema/security/oauth2 http://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd
+       xmlns:oauth="http://www.springframework.org/schema/security/oauth2"
+       xmlns:security="http://www.springframework.org/schema/security"
+       xsi:schemaLocation="http://www.springframework.org/schema/security/oauth2 http://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd
         http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd">
 
-	<!-- Resource Service interface secured via OAuth2 -->
-    <security:http pattern="/"
-    	  		   create-session="never"
-    	  		   entry-point-ref="oauthAuthenticationEntryPoint"
-    	  		   access-decision-manager-ref="accessDecisionManager">
+    <security:http pattern="/" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint"
+                   access-decision-manager-ref="accessDecisionManager">
 
-        <!-- resources below /secured/get/resource/ are accessed via scope "READ" -->
         <security:intercept-url pattern="/**" access="SCOPE_DYNAMIC"/>
-
-        <!-- validates the delivered access token -->
         <security:custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER"/>
-
-        <!-- uses general oauthAccessDeniedHandler -->
         <security:access-denied-handler ref="oauthAccessDeniedHandler"/>
     </security:http>
 
-    <security:http create-session="never"
-    			   access-decision-manager-ref="accessDecisionManager"
-    			   entry-point-ref="oauthAuthenticationEntryPoint"
-    			   pattern="/Client/**">
+    <security:http pattern="/Client/**" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint"
+                   access-decision-manager-ref="accessDecisionManager">
 
-        <!-- resources below /secured/get/resource/ are accessed via scope "READ" -->
-        <security:intercept-url pattern="/Client/**" access="SCOPE_DYNAMIC" />
-
-        <!-- validates the delivered access token -->
-        <security:custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER" />
-
-        <!-- uses general oauthAccessDeniedHandler -->
-        <security:access-denied-handler ref="oauthAccessDeniedHandler" />
-    </security:http>
-    
-    <security:http create-session="never"
-                   entry-point-ref="oauthAuthenticationEntryPoint"
-                   pattern="/token/**">
-
-        <!-- resources below /secured/get/resource/ are accessed via scope "READ" -->
-        <security:intercept-url pattern="/token/**" access="IS_AUTHENTICATED_FULLY" />
-
-        <!-- validates the delivered access token -->
-        <security:custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER" />
-
-        <!-- uses general oauthAccessDeniedHandler -->
-        <security:access-denied-handler ref="oauthAccessDeniedHandler" />
+        <security:intercept-url pattern="/Client/**" access="SCOPE_DYNAMIC"/>
+        <security:custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER"/>
+        <security:access-denied-handler ref="oauthAccessDeniedHandler"/>
     </security:http>
 
-    <!-- entry point for OAuth2 secured resources -->
+    <security:http pattern="/token/**" create-session="never" entry-point-ref="oauthAuthenticationEntryPoint">
+
+        <security:intercept-url pattern="/token/**" access="IS_AUTHENTICATED_FULLY"/>
+        <security:custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER"/>
+        <security:access-denied-handler ref="oauthAccessDeniedHandler"/>
+    </security:http>
+
     <bean id="oauthAuthenticationEntryPoint"
           class="org.springframework.security.oauth2.provider.error.OAuth2AuthenticationEntryPoint">
+
         <property name="realmName" value="oauth2-authorization-server"/>
     </bean>
 
-    <!-- general access decision manager for OAuth2 secured resources -->
     <bean id="accessDecisionManager" class="org.springframework.security.access.vote.UnanimousBased"
           xmlns="http://www.springframework.org/schema/beans">
+
         <constructor-arg>
             <list>
                 <bean class="org.osiam.security.authorization.DynamicHTTPMethodScopeEnhancer">
@@ -94,8 +72,7 @@
         </constructor-arg>
     </bean>
 
-    <security:authentication-manager />
-    
-    <!-- filter to validate the delivered access token -->
+    <security:authentication-manager/>
+
     <oauth:resource-server id="resourceServerFilter" resource-id="oauth2res" token-services-ref="tokenServices"/>
 </beans>

--- a/src/test/groovy/org/osiam/security/controller/TokenControllerSpec.groovy
+++ b/src/test/groovy/org/osiam/security/controller/TokenControllerSpec.groovy
@@ -23,8 +23,6 @@
 
 package org.osiam.security.controller
 
-import java.lang.reflect.Method
-
 import org.osiam.auth.login.ResourceServerConnector
 import org.osiam.client.oauth.AccessToken;
 import org.osiam.client.oauth.Scope;
@@ -35,18 +33,13 @@ import org.springframework.security.oauth2.common.OAuth2AccessToken
 import org.springframework.security.oauth2.provider.AuthorizationRequest
 import org.springframework.security.oauth2.provider.OAuth2Authentication
 import org.springframework.security.oauth2.provider.token.DefaultTokenServices
-import org.springframework.stereotype.Controller
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.ResponseBody
-
 import spock.lang.Specification
 
 class TokenControllerSpec extends Specification {
 
     DefaultTokenServices defaultTokenServicesMock = Mock()
     ResourceServerConnector resourceServerConnectorMock = Mock()
-    TokenController tokenController = new TokenController(tokenServices: defaultTokenServicesMock, 
+    TokenController tokenController = new TokenController(tokenServices: defaultTokenServicesMock,
         resourceServerConnector: resourceServerConnectorMock)
 
     def 'The TokenController should return an accesstoken with all attributes set'() {
@@ -57,9 +50,9 @@ class TokenControllerSpec extends Specification {
         Authentication authentication = Mock()
         User user = new User.Builder('username').setId('userId').build()
         Date date = new Date()
-        
+
         when:
-        AccessToken result = tokenController.tokenValidation('accessToken')
+        AccessToken result = tokenController.validateToken('accessToken')
 
         then:
         1 * defaultTokenServicesMock.loadAuthentication('accessToken') >> auth
@@ -76,10 +69,10 @@ class TokenControllerSpec extends Specification {
         result.scopes.contains(new Scope('GET'))
         result.expiresAt == date
     }
-    
+
     def 'OSNG-444: A request to revoke a token should be delegated to the TokenService'() {
         when:
-        tokenController.tokenRevocation('prefix accessToken')
+        tokenController.revokeToken('prefix accessToken')
 
         then:
         1 * defaultTokenServicesMock.revokeToken('accessToken')
@@ -95,7 +88,7 @@ class TokenControllerSpec extends Specification {
         OAuth2AccessToken token3 = new DefaultOAuth2AccessToken('token3')
 
         when:
-        tokenController.tokenRevocation(userId, 'prefix accessToken')
+        tokenController.revokeAllTokensOfUser(userId)
 
         then:
         1 * resourceServerConnectorMock.getUserById(userId) >> user
@@ -113,7 +106,7 @@ class TokenControllerSpec extends Specification {
         User user = new User.Builder(userName).setId(userId).build()
 
         when:
-        tokenController.tokenRevocation(userId, 'prefix accessToken')
+        tokenController.revokeAllTokensOfUser(userId)
 
         then:
         1 * resourceServerConnectorMock.getUserById(userId) >> user


### PR DESCRIPTION
This leads to rejection of revocations of other user's access tokens with `ME` scope and rejection of every revocation without `POST` scope.
