### PR TITLE
Add Flyway migration to replace method-based scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 ## Unreleased
 
+**Potentially breaking changes!**
+
 ### Changes
 
 - Update OSIAM connector4java
 - Remove usage of old, method-based OAuth scopes
 - Remove support for old, method-based OAuth scopes
+- Add Flyway migration to replace method-based scopes
+
+    The migration will remove all old, method-based scopes from every client and
+    then add the new scopes `ADMIN` and `ME`. See the [migration notes]
+    (docs/Migration.md#from-22-to-30) for further details.
 
 ### Fixes
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,3 +1,23 @@
+# Migration Notes
+
+## from 2.2 to 3.0
+
+This release removes the old, HTTP method-based scopes and replaces them with
+the new, functional-motivated scopes `ADMIN` and `ME`. The auth-server will
+automatically migrate all clients to the new scopes in the following way:
+
+1. Remove the old scopes (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`)
+2. Add the new scopes (`ADMIN`, `ME`)
+
+It will not touch self-defined scopes! Please check the scopes of your clients
+after the migration to ensure that everything is like you would expect. You
+maybe have to remove the new scopes from your clients if they don't use them.
+
+**Beware:** having a scope like `ADMIN` defined for your client can lead to
+security issues if you allow untrusted entities to request access tokens with
+whatever scopes they want. Please double check, that after the migration your
+clients don't define more scopes than they should.
+
 ## from 1.3.x to 2.0
 
 Flyway was added to support schema upgrades for the next versions. To

--- a/src/main/java/db/migration/V4__replace_old_scopes.java
+++ b/src/main/java/db/migration/V4__replace_old_scopes.java
@@ -1,0 +1,39 @@
+package db.migration;
+
+import java.util.List;
+
+import org.flywaydb.core.api.migration.spring.SpringJdbcMigration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class V4__replace_old_scopes implements SpringJdbcMigration {
+
+    @Override
+    public void migrate(JdbcTemplate jdbcTemplate) throws Exception {
+        List<Long> clientIds = jdbcTemplate.queryForList("select internal_id from osiam_client", Long.class);
+        for (Long clientId : clientIds) {
+            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", clientId, "GET");
+            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", clientId, "POST");
+            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", clientId, "PUT");
+            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", clientId, "PATCH");
+            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", clientId, "DELETE");
+
+            jdbcTemplate.update("INSERT INTO osiam_client_scopes (id, scope) VALUES (?, ?)", clientId, "ADMIN");
+            jdbcTemplate.update("INSERT INTO osiam_client_scopes (id, scope) VALUES (?, ?)", clientId, "ME");
+        }
+
+        updateKnownClient("auth-server", jdbcTemplate);
+        updateKnownClient("addon-administration-client", jdbcTemplate);
+        updateKnownClient("addon-self-administration-client", jdbcTemplate);
+    }
+
+    private void updateKnownClient(String clientId, JdbcTemplate jdbcTemplate) {
+        List<Long> ids = jdbcTemplate.queryForList(
+                "select internal_id from osiam_client where id = ?",
+                new Object[] { clientId },
+                Long.class
+        );
+        for (Long id : ids) {
+            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", id, "ME");
+        }
+    }
+}

--- a/src/main/java/db/migration/mysql/V4__replace_old_scopes.java
+++ b/src/main/java/db/migration/mysql/V4__replace_old_scopes.java
@@ -1,0 +1,4 @@
+package db.migration.mysql;
+
+public class V4__replace_old_scopes extends db.migration.V4__replace_old_scopes {
+}

--- a/src/main/java/db/migration/postgresql/V4__replace_old_scopes.java
+++ b/src/main/java/db/migration/postgresql/V4__replace_old_scopes.java
@@ -1,0 +1,4 @@
+package db.migration.postgresql;
+
+public class V4__replace_old_scopes extends db.migration.V4__replace_old_scopes {
+}


### PR DESCRIPTION
The migration will remove all old, method-based scopes from every client
and then add the new scopes `ADMIN` and `ME`. The scope `ME` will not be
added for well-known clients like `addon-administration`,
`addon-self-administration` and `auth-server`. The migration is
implemented as a Java migration due to it's complex nature.

See also osiam/osiam#23
