### PR TITLE
Prevent NPE when `User#active` is null

### DIFF
--- a/src/main/java/org/osiam/auth/login/internal/InternalAuthenticationProvider.java
+++ b/src/main/java/org/osiam/auth/login/internal/InternalAuthenticationProvider.java
@@ -91,7 +91,7 @@ public class InternalAuthenticationProvider implements AuthenticationProvider,
             throw new BadCredentialsException("The user with the username '" + username + "' doesn't exist!");
         }
 
-        if (!user.isActive()) {
+        if (user.isActive() != Boolean.TRUE) {
             throw new DisabledException("The user with the username '" + username + "' is disabled!");
         }
 


### PR DESCRIPTION
fixes #8
