### PR TITLE
Improve db migration for removal of old scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
 - Remove support for old, method-based OAuth scopes
 - Add Flyway migration to replace method-based scopes
 
-    The migration will remove all old, method-based scopes from every client and
-    then add the new scopes `ADMIN` and `ME`. See the [migration notes]
-    (docs/Migration.md#from-22-to-30) for further details.
+    The migration will remove all old, method-based scopes from all well-known
+    clients and then add the new scopes `ADMIN` and `ME`. See the
+    [migration notes] (docs/Migration.md#from-22-to-30) for further details.
 
 ### Fixes
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,19 +4,39 @@
 
 This release removes the old, HTTP method-based scopes and replaces them with
 the new, functional-motivated scopes `ADMIN` and `ME`. The auth-server will
-automatically migrate all clients to the new scopes in the following way:
+automatically migrate all well-known clients to the new scopes in the following
+way:
 
 1. Remove the old scopes (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`)
 2. Add the new scopes (`ADMIN`, `ME`)
 
-It will not touch self-defined scopes! Please check the scopes of your clients
-after the migration to ensure that everything is like you would expect. You
-maybe have to remove the new scopes from your clients if they don't use them.
+Well-known clients and their scopes are:
+
+* `example-client` (`ADMIN`, `ME`)
+* `auth-server` (`ADMIN`)
+* `addon-self-administration-client` (`ADMIN`)
+* `addon-administration-client` (`ADMIN`)
+
+The migration will not touch self-defined scopes nor self-defined clients!
+Before deploying the auth-server and resource-server (and thus run the automatic
+migration) update your existing clients:
+
+1. Examine the current scopes and usages of the client.
+2. Should access tokens granted to this client have full administrative access to OSIAM?
+  1. Add scope `ADMIN`
+3. Should access tokens granted to this client have only access to the associated user?
+  1. Add scope `ME`
+4. Remove the old scopes (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`)
+5. Deploy the auth-server
+
+**Note:** The new scopes ADMIN and ME have been supported since the last
+release, to make it possible to just switch to them without upgrading OSIAM and
+still have everything work as expected. This way you can schedule an upgrade at
+your own convenience and minimize downtime.
 
 **Beware:** having a scope like `ADMIN` defined for your client can lead to
 security issues if you allow untrusted entities to request access tokens with
-whatever scopes they want. Please double check, that after the migration your
-clients don't define more scopes than they should.
+whatever scopes they want.
 
 ## from 1.3.x to 2.0
 

--- a/src/main/java/db/migration/V4__replace_old_scopes.java
+++ b/src/main/java/db/migration/V4__replace_old_scopes.java
@@ -4,13 +4,16 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.flywaydb.core.api.migration.MigrationChecksumProvider;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 
 public class V4__replace_old_scopes implements JdbcMigration, MigrationChecksumProvider {
+
+    private final Map<String, Long> internalIds = new HashMap<>();
+    private Connection connection;
 
     @Override
     public Integer getChecksum() {
@@ -19,70 +22,62 @@ public class V4__replace_old_scopes implements JdbcMigration, MigrationChecksumP
 
     @Override
     public void migrate(Connection connection) throws Exception {
-        List<Long> clientIds = clientIds(connection);
-        for (Long clientId : clientIds) {
-            removeScopeFromClient(clientId, "GET", connection);
-            removeScopeFromClient(clientId, "POST", connection);
-            removeScopeFromClient(clientId, "PUT", connection);
-            removeScopeFromClient(clientId, "PATCH", connection);
-            removeScopeFromClient(clientId, "DELETE", connection);
-
-            addScopeToClient(clientId, "ADMIN", connection);
-            addScopeToClient(clientId, "ME", connection);
-        }
-
-        removeScopeFromClient(toInternalId("auth-server", connection), "ME", connection);
-        removeScopeFromClient(toInternalId("addon-administration-client", connection), "ME", connection);
-        removeScopeFromClient(toInternalId("addon-self-administration-client", connection), "ME", connection);
+        this.connection = connection;
+        removeScopesFromClient("example-client", "GET", "POST", "PUT", "PATCH", "DELETE");
+        addScopesToClient("example-client", "ADMIN", "ME");
+        removeScopesFromClient("auth-server", "GET", "POST", "PUT", "PATCH", "DELETE");
+        addScopesToClient("auth-server", "ADMIN");
+        removeScopesFromClient("addon-self-administration-client", "GET", "POST", "PUT", "PATCH", "DELETE");
+        addScopesToClient("addon-self-administration-client", "ADMIN");
+        removeScopesFromClient("addon-administration-client", "GET", "POST", "PUT", "PATCH", "DELETE");
+        addScopesToClient("addon-administration-client", "ADMIN");
     }
 
-    private List<Long> clientIds(Connection connection) throws SQLException {
-        List<Long> result = new ArrayList<>();
-        try (PreparedStatement statement = connection.prepareStatement("select internal_id from osiam_client")) {
-            ResultSet resultSet = statement.executeQuery();
-            while (resultSet.next()) {
-                long clientId = resultSet.getLong(1);
-                result.add(clientId);
-            }
-            return result;
-        }
-    }
-
-    private void removeScopeFromClient(Long clientId, String scope, Connection connection) throws SQLException {
-        if(clientId < 0) {
+    private void removeScopesFromClient(String clientId, String... scopes) throws SQLException {
+        long internalId = toInternalId(clientId);
+        if (internalId < 0) {
             return;
         }
-        try (PreparedStatement statement = connection
-                .prepareStatement("delete from osiam_client_scopes where id = ? and scope = ?")) {
-            statement.setLong(1, clientId);
-            statement.setString(2, scope);
-            statement.execute();
+        for (String scope : scopes) {
+            try (PreparedStatement statement = connection
+                    .prepareStatement("delete from osiam_client_scopes where id = ? and scope = ?")) {
+                statement.setLong(1, internalId);
+                statement.setString(2, scope);
+                statement.execute();
+            }
         }
     }
 
-    private void addScopeToClient(Long clientId, String scope, Connection connection) throws SQLException {
-        if(clientId < 0) {
+    private void addScopesToClient(String clientId, String... scopes) throws SQLException {
+        long internalId = toInternalId(clientId);
+        if (internalId < 0) {
             return;
         }
-        try (PreparedStatement statement = connection
-                .prepareStatement("insert into osiam_client_scopes (id, scope) values (?, ?)")) {
-            statement.setLong(1, clientId);
-            statement.setString(2, scope);
-            statement.execute();
+        for (String scope : scopes) {
+            try (PreparedStatement statement = connection
+                    .prepareStatement("insert into osiam_client_scopes (id, scope) values (?, ?)")) {
+                statement.setLong(1, internalId);
+                statement.setString(2, scope);
+                statement.execute();
+            }
         }
     }
 
-    private long toInternalId(String clientId, Connection connection) {
-        try (PreparedStatement statement = connection
-                .prepareStatement("select internal_id from osiam_client where id = ?")) {
-            statement.setString(1, clientId);
-            ResultSet resultSet = statement.executeQuery();
-            if (resultSet.next()) {
-                return resultSet.getLong(1);
+    private long toInternalId(String clientId) {
+        if (!internalIds.containsKey(clientId)) {
+            try (PreparedStatement statement = connection
+                    .prepareStatement("select internal_id from osiam_client where id = ?")) {
+                statement.setString(1, clientId);
+                ResultSet resultSet = statement.executeQuery();
+                if (resultSet.next()) {
+                    internalIds.put(clientId, resultSet.getLong(1));
+                } else {
+                    internalIds.put(clientId, -1L);
+                }
+            } catch (SQLException e) {
+                internalIds.put(clientId, -1L);
             }
-            return -1;
-        } catch (SQLException e) {
-            return -1;
         }
+        return internalIds.get(clientId);
     }
 }

--- a/src/main/java/db/migration/V4__replace_old_scopes.java
+++ b/src/main/java/db/migration/V4__replace_old_scopes.java
@@ -1,39 +1,88 @@
 package db.migration;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
-import org.flywaydb.core.api.migration.spring.SpringJdbcMigration;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.flywaydb.core.api.migration.MigrationChecksumProvider;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 
-public class V4__replace_old_scopes implements SpringJdbcMigration {
+public class V4__replace_old_scopes implements JdbcMigration, MigrationChecksumProvider {
 
     @Override
-    public void migrate(JdbcTemplate jdbcTemplate) throws Exception {
-        List<Long> clientIds = jdbcTemplate.queryForList("select internal_id from osiam_client", Long.class);
-        for (Long clientId : clientIds) {
-            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", clientId, "GET");
-            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", clientId, "POST");
-            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", clientId, "PUT");
-            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", clientId, "PATCH");
-            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", clientId, "DELETE");
-
-            jdbcTemplate.update("INSERT INTO osiam_client_scopes (id, scope) VALUES (?, ?)", clientId, "ADMIN");
-            jdbcTemplate.update("INSERT INTO osiam_client_scopes (id, scope) VALUES (?, ?)", clientId, "ME");
-        }
-
-        updateKnownClient("auth-server", jdbcTemplate);
-        updateKnownClient("addon-administration-client", jdbcTemplate);
-        updateKnownClient("addon-self-administration-client", jdbcTemplate);
+    public Integer getChecksum() {
+        return 1546262391;
     }
 
-    private void updateKnownClient(String clientId, JdbcTemplate jdbcTemplate) {
-        List<Long> ids = jdbcTemplate.queryForList(
-                "select internal_id from osiam_client where id = ?",
-                new Object[] { clientId },
-                Long.class
-        );
-        for (Long id : ids) {
-            jdbcTemplate.update("DELETE FROM osiam_client_scopes WHERE id = ? and scope = ?", id, "ME");
+    @Override
+    public void migrate(Connection connection) throws Exception {
+        List<Long> clientIds = clientIds(connection);
+        for (Long clientId : clientIds) {
+            removeScopeFromClient(clientId, "GET", connection);
+            removeScopeFromClient(clientId, "POST", connection);
+            removeScopeFromClient(clientId, "PUT", connection);
+            removeScopeFromClient(clientId, "PATCH", connection);
+            removeScopeFromClient(clientId, "DELETE", connection);
+
+            addScopeToClient(clientId, "ADMIN", connection);
+            addScopeToClient(clientId, "ME", connection);
+        }
+
+        removeScopeFromClient(toInternalId("auth-server", connection), "ME", connection);
+        removeScopeFromClient(toInternalId("addon-administration-client", connection), "ME", connection);
+        removeScopeFromClient(toInternalId("addon-self-administration-client", connection), "ME", connection);
+    }
+
+    private List<Long> clientIds(Connection connection) throws SQLException {
+        List<Long> result = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement("select internal_id from osiam_client")) {
+            ResultSet resultSet = statement.executeQuery();
+            while (resultSet.next()) {
+                long clientId = resultSet.getLong(1);
+                result.add(clientId);
+            }
+            return result;
+        }
+    }
+
+    private void removeScopeFromClient(Long clientId, String scope, Connection connection) throws SQLException {
+        if(clientId < 0) {
+            return;
+        }
+        try (PreparedStatement statement = connection
+                .prepareStatement("delete from osiam_client_scopes where id = ? and scope = ?")) {
+            statement.setLong(1, clientId);
+            statement.setString(2, scope);
+            statement.execute();
+        }
+    }
+
+    private void addScopeToClient(Long clientId, String scope, Connection connection) throws SQLException {
+        if(clientId < 0) {
+            return;
+        }
+        try (PreparedStatement statement = connection
+                .prepareStatement("insert into osiam_client_scopes (id, scope) values (?, ?)")) {
+            statement.setLong(1, clientId);
+            statement.setString(2, scope);
+            statement.execute();
+        }
+    }
+
+    private long toInternalId(String clientId, Connection connection) {
+        try (PreparedStatement statement = connection
+                .prepareStatement("select internal_id from osiam_client where id = ?")) {
+            statement.setString(1, clientId);
+            ResultSet resultSet = statement.executeQuery();
+            if (resultSet.next()) {
+                return resultSet.getLong(1);
+            }
+            return -1;
+        } catch (SQLException e) {
+            return -1;
         }
     }
 }


### PR DESCRIPTION
This PR consists of 2 things:
1. Make the migration work with the Flyway command line client, which is
   necessary for the Docker image, Vagrant VM, etc.
2. Change migration to only touch clients that are well-known to OSIAM.

See individual commit messages for further details.
