### PR TITLE
Remove explicit dependency on Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,24 +162,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.5.4</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.5.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.5.4</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>2.4.5</version>


### PR DESCRIPTION
After we restored compatibility of the connector with older Jackson version, we can now remove the explicit dependency on Jackson. Spring Boot already defines a working Jackson version that we should use. This way we reduce the complexity of the POM and also get automatic updates with new Spring Boot releases instead of relying on the explicit version, which will be outdated in the future.
