### PR TITLE
Increase timeouts and parallel connections to resource-server

### DIFF
--- a/src/main/java/org/osiam/auth/login/ResourceServerConnector.java
+++ b/src/main/java/org/osiam/auth/login/ResourceServerConnector.java
@@ -50,6 +50,11 @@ public class ResourceServerConnector {
     @Autowired
     private OsiamAuthServerClientProvider authServerClientProvider;
 
+    static {
+        OsiamConnector.setMaxConnections(40);
+        OsiamConnector.setMaxConnectionsPerRoute(40);
+    }
+
     public User getUserByUsername(final String userName) {
         Query query = new QueryBuilder().filter("userName eq \"" + userName + "\"").build();
 
@@ -91,10 +96,13 @@ public class ResourceServerConnector {
     }
 
     private OsiamConnector createOsiamConnector() {
-        return new OsiamConnector.Builder().
-                setAuthServerEndpoint(authServerHome).
-                setResourceServerEndpoint(resourceServerHome).
-                setClientId(OsiamAuthServerClientProvider.AUTH_SERVER_CLIENT_ID).
-                setClientSecret(authServerClientProvider.getClientSecret()).build();
+        return new OsiamConnector.Builder()
+                .setAuthServerEndpoint(authServerHome)
+                .setResourceServerEndpoint(resourceServerHome)
+                .setClientId(OsiamAuthServerClientProvider.AUTH_SERVER_CLIENT_ID)
+                .setClientSecret(authServerClientProvider.getClientSecret())
+                .withReadTimeout(10000)
+                .withConnectTimeout(5000)
+                .build();
     }
 }


### PR DESCRIPTION
We had some issues with too many parallel request to the auth-server. It turned out that requests to the resource-server, which are necessary to validate the user's credentials, queue up in the HTTP connection pool queue, which leads to timeouts of the auth-server client's access token, making the request fail with "Your token is invalid" messages.
