### PR TITLE
Extend configuration by parameters for pools and timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Make connector properties configurable
+- Make JDBC pool properties configurable
 
 ## 2.3 - 2015-10-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OSIAM auth server
 
+## 2.4 - Unreleased
+
+### Features
+
+- Make connector properties configurable
+
 ## 2.3 - 2015-10-09
 
 ### Features

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,8 +18,13 @@ org.osiam.auth-server.db.password=<YOUR_PASSWORD>
 # Home URL (needed for self reference)
 org.osiam.auth-server.home=http://localhost:8080/osiam-auth-server
 
-# OSIAM resource server configuration
+# OSIAM resource-server configuration
 org.osiam.resource-server.home=http://localhost:8080/osiam-resource-server
+# Maximum number of parallel connections to the resource-server
+org.osiam.resource-server.connector.max-connections=40
+# Timeouts of connections to resource-server in milliseconds
+org.osiam.resource-server.connector.read-timeout-ms=10000
+org.osiam.resource-server.connector.connect-timeout-ms=5000
 
 # LDAP config for auth server
 org.osiam.auth-server.ldap.enabled=true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,9 +20,6 @@ org.osiam.auth-server.home=http://localhost:8080/osiam-auth-server
 
 # OSIAM resource server configuration
 org.osiam.resource-server.home=http://localhost:8080/osiam-resource-server
-# ATTENTION: you have to set a random secret for the resource server client!
-# It has to be the same as in the properties file of the resource server!
-org.osiam.resource-server.client.secret=secret
 
 # LDAP config for auth server
 org.osiam.auth-server.ldap.enabled=true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,10 @@ org.osiam.auth-server.db.url=jdbc:postgresql://localhost:5432/ong
 org.osiam.auth-server.db.username=ong
 org.osiam.auth-server.db.password=<YOUR_PASSWORD>
 
+# JDBC pool properties
+org.osiam.auth-server.db.maximum-pool-size=10
+org.osiam.auth-server.db.connection-timeout-ms=30000
+
 # OSIAM authentication-server configuration
 # Home URL (needed for self reference)
 org.osiam.auth-server.home=http://localhost:8080/osiam-auth-server

--- a/src/main/deploy/auth-server.properties
+++ b/src/main/deploy/auth-server.properties
@@ -12,6 +12,11 @@ org.osiam.auth-server.home=http://localhost:8080/osiam-auth-server
 
 # OSIAM resource server configuration
 org.osiam.resource-server.home=http://localhost:8080/osiam-resource-server
+# Maximum number of parallel connections to the resource-server
+org.osiam.resource-server.connector.max-connections=40
+# Timeouts of connections to resource-server in milliseconds
+org.osiam.resource-server.connector.read-timeout-ms=10000
+org.osiam.resource-server.connector.connect-timeout-ms=5000
 
 # LDAP config for auth server
 org.osiam.auth-server.ldap.enabled=false

--- a/src/main/deploy/auth-server.properties
+++ b/src/main/deploy/auth-server.properties
@@ -6,6 +6,10 @@ org.osiam.auth-server.db.url=jdbc:postgresql://localhost:5432/ong
 org.osiam.auth-server.db.username=ong
 org.osiam.auth-server.db.password=b4s3dg0d
 
+# JDBC pool properties
+org.osiam.auth-server.db.maximum-pool-size=10
+org.osiam.auth-server.db.connection-timeout-ms=30000
+
 # OSIAM authentication-server configuration
 # Home URL (needed for self reference)
 org.osiam.auth-server.home=http://localhost:8080/osiam-auth-server

--- a/src/main/java/org/osiam/auth/login/ResourceServerConnector.java
+++ b/src/main/java/org/osiam/auth/login/ResourceServerConnector.java
@@ -31,13 +31,14 @@ import org.osiam.client.query.QueryBuilder;
 import org.osiam.resources.scim.SCIMSearchResult;
 import org.osiam.resources.scim.UpdateUser;
 import org.osiam.resources.scim.User;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
 
 @Service
-public class ResourceServerConnector {
+public class ResourceServerConnector implements InitializingBean{
 
     @Value("${org.osiam.resource-server.home}")
     private String resourceServerHome;
@@ -45,17 +46,27 @@ public class ResourceServerConnector {
     @Value("${org.osiam.auth-server.home}")
     private String authServerHome;
 
+    @Value("${org.osiam.resource-server.connector.max-connections:40}")
+    private int maxConnections;
+
+    @Value("${org.osiam.resource-server.connector.read-timeout-ms:10000}")
+    private int readTimeout;
+
+    @Value("${org.osiam.resource-server.connector.connect-timeout-ms:5000}")
+    private int connectTimeout;
+
     @Inject
     private OsiamAccessTokenProvider osiamAccessTokenProvider;
 
     @Inject
     private OsiamAuthServerClientProvider authServerClientProvider;
 
-    static {
-        OsiamConnector.setMaxConnections(40);
-        OsiamConnector.setMaxConnectionsPerRoute(40);
-        OsiamConnector.setReadTimeout(10000);
-        OsiamConnector.setConnectTimeout(5000);
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        OsiamConnector.setMaxConnections(maxConnections);
+        OsiamConnector.setMaxConnectionsPerRoute(maxConnections);
+        OsiamConnector.setReadTimeout(readTimeout);
+        OsiamConnector.setConnectTimeout(connectTimeout);
     }
 
     public User getUserByUsername(final String userName) {

--- a/src/main/webapp/WEB-INF/jpa-configuration.xml
+++ b/src/main/webapp/WEB-INF/jpa-configuration.xml
@@ -56,6 +56,9 @@
         <property name="jdbcUrl" value="${org.osiam.auth-server.db.url}" />
         <property name="username" value="${org.osiam.auth-server.db.username}" />
         <property name="password" value="${org.osiam.auth-server.db.password}" />
+        <property name="connectionTimeout"
+                  value="${org.osiam.auth-server.db.connection-timeout-ms:30000}"/>
+        <property name="maximumPoolSize" value="${org.osiam.auth-server.db.maximum-pool-size:10}"/>
     </bean>
 
     <bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">


### PR DESCRIPTION
This is part of the efforts to support more parallel requests. See also #81.

Resolves #81
